### PR TITLE
Add amazon.aws module to utility container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -81,7 +81,7 @@ rm -rf /root/anaconda* /root/original-ks.cfg /usr/local/README
 # otherwise whatever user openshift runs the container with won't find the collection
 
 RUN pip3 install --no-cache-dir "ansible-core>=2.9" kubernetes openshift "boto3>=1.21" "botocore>=1.24" "awscli>=1.22" "azure-cli>=2.34" gcloud humanize --upgrade && \
-ansible-galaxy collection install --collections-path /usr/share/ansible/collections kubernetes.core redhat_cop.controller_configuration && \
+ansible-galaxy collection install --collections-path /usr/share/ansible/collections kubernetes.core redhat_cop.controller_configuration amazon.aws && \
 rm -rf /usr/local/lib/python3.9/site-packages/ansible_collections/$COLLECTIONS_TO_REMOVE && \
 curl -L -O https://raw.githubusercontent.com/clumio-code/azure-sdk-trim/main/azure_sdk_trim/azure_sdk_trim.py && \
 python azure_sdk_trim.py && rm azure_sdk_trim.py && pip3 uninstall -y humanize && \


### PR DESCRIPTION
- Added amazon.aws to the Ansible collection install list

# /usr/share/ansible/collections/ansible_collections
Collection                          Version
----------------------------------- -------
amazon.aws                          7.5.0  
kubernetes.core                     3.0.1  
redhat_cop.controller_configuration 2.3.1  

