### PR TITLE
Include both redhat_cop and infra controller_configuration collections

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -82,7 +82,7 @@ rm -rf /root/anaconda* /root/original-ks.cfg /usr/local/README
 
 RUN pip3 install --no-cache-dir "ansible-core>=2.9" kubernetes openshift "boto3>=1.21" "botocore>=1.24" "awscli>=1.22" "azure-cli>=2.34" gcloud humanize jmespath awxkit --upgrade && \
 pip3 install --no-cache-dir git+https://github.com/validatedpatterns/vp-qe-test-common.git@development#egg=vp-qe-test-common --upgrade && \
-ansible-galaxy collection install --collections-path /usr/share/ansible/collections ansible.posix ansible.utils kubernetes.core community.okd infra.controller_configuration community.general awx.awx amazon.aws && \
+ansible-galaxy collection install --collections-path /usr/share/ansible/collections ansible.posix ansible.utils kubernetes.core community.okd redhat_cop.controller_configuration infra.controller_configuration community.general awx.awx amazon.aws && \
 rm -rf /usr/local/lib/python3.9/site-packages/ansible_collections/$COLLECTIONS_TO_REMOVE && \
 curl -L -O https://raw.githubusercontent.com/clumio-code/azure-sdk-trim/main/azure_sdk_trim/azure_sdk_trim.py && \
 python azure_sdk_trim.py && rm azure_sdk_trim.py && pip3 uninstall -y humanize && \

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ TESTCOMMAND := "set -e; echo '* Helm: '; helm version; \
 		echo '* Python: '; python --version ; \
 		echo '* Ansible: '; ansible --version ; \
 		echo '* kubernetes.core: '; ansible-galaxy collection list | grep kubernetes.core ; \
+		echo '* redhat_cop.controller_configuration: '; ansible-galaxy collection list | grep redhat_cop.controller_configuration ; \
 		echo '* infra.controller_configuration: '; ansible-galaxy collection list | grep infra.controller_configuration ; \
 		echo '* awx.awx: '; ansible-galaxy collection list | grep awx.awx ; \
 		echo '* community.general: '; ansible-galaxy collection list | grep community.general ; \
@@ -113,6 +114,7 @@ versions: ## Print all the versions of software in the locally-built container
 		echo -n \"|awx.awx collection \";  ansible-galaxy collection list awx.awx |grep ^awx.awx | tr -s ' ' | cut -f2 -d ' '  |tr -d '\n';  echo \" \"; \
 		echo -n \"|ansible.posix collection \";  ansible-galaxy collection list ansible.posix |grep ^ansible.posix | cut -f2 -d\  |tr -d '\n';  echo \" \"; \
 		echo -n \"|ansible.utils collection \";  ansible-galaxy collection list ansible.utils |grep ^ansible.utils | cut -f2 -d\  |tr -d '\n';  echo \" \"; \
+		echo -n \"|redhat_cop.controller_configuration collection \";  ansible-galaxy collection list redhat_cop.controller_configuration |grep ^redhat_cop.controller_configuration | cut -f2 -d\ | tr -d '\n'; echo \" \";  \
 		echo -n \"|infra.controller_configuration collection \";  ansible-galaxy collection list infra.controller_configuration |grep ^infra.controller_configuration | cut -f2 -d\ | tr -d '\n'; echo \" \";  \
     " | sort | column --table -o '|'
 

--- a/README.md
+++ b/README.md
@@ -7,38 +7,39 @@ utility container for simplified execution of imperative commands in each of the
 
 |               name                |  type    |   version    |
 |:---------------------------------:|:--------:|:------------:|
-|ansible                       |pip       |2.15.12       |
-|ansible.posix                 |collection|1.5.4         |
-|ansible.utils                 |collection|5.0.0         |
-|argocd                        |binary    |v2.9.7+fbb6b20|
-|awscli                        |pip       |1.33.32       |
-|awx.awx                       |collection|24.6.1        |
-|awxkit                        |pip       |24.6.1        |
-|azure-cli                     |pip       |2.62.0        |
-|boto3                         |pip       |1.34.150      |
-|botocore                      |pip       |1.34.150      |
-|community.general             |collection|9.2.0         |
-|community.okd                 |collection|4.0.0         |
-|gcloud                        |pip       |0.18.3        |
-|git-core                      |package   |2.43.5        |
-|hcp                           |binary    |4.15.0        |
-|helm                          |binary    |v3.13.3       |
-|infra.controller_configuration|collection|2.9.0         |
-|jmespath                      |pip       |1.0.1         |
-|jq                            |package   |1.6           |
-|kubernetes.core               |collection|5.0.0         |
-|kubernetes                    |pip       |30.1.0        |
-|kustomize                     |binary    |v5.0.1        |
-|make                          |package   |4.3           |
-|openshift                     |binary    |4.14.20       |
-|python3-pip                   |package   |21.2.3        |
-|python3-pytest                |package   |6.2.2         |
-|python                        |package   |3.9.18        |
-|sshpass                       |package   |1.09          |
-|tar                           |package   |1.34          |
-|tekton                        |binary    |0.35.2        |
-|vi                            |package   |8.2.2637      |
-|vp-qe-test-common             |pip       |0.1.0         |
+|ansible                            |pip       |2.15.12       |
+|ansible.posix                      |collection|1.5.4         |
+|ansible.utils                      |collection|5.0.0         |
+|argocd                             |binary    |v2.9.7+fbb6b20|
+|awscli                             |pip       |1.33.33       |
+|awx.awx                            |collection|24.6.1        |
+|awxkit                             |pip       |24.6.1        |
+|azure-cli                          |pip       |2.62.0        |
+|boto3                              |pip       |1.34.151      |
+|botocore                           |pip       |1.34.151      |
+|community.general                  |collection|9.2.0         |
+|community.okd                      |collection|4.0.0         |
+|gcloud                             |pip       |0.18.3        |
+|git-core                           |package   |2.43.5        |
+|hcp                                |binary    |4.15.0        |
+|helm                               |binary    |v3.13.3       |
+|infra.controller_configuration     |collection|2.9.0         |
+|jmespath                           |pip       |1.0.1         |
+|jq                                 |package   |1.6           |
+|kubernetes.core                    |collection|5.0.0         |
+|kubernetes                         |pip       |30.1.0        |
+|kustomize                          |binary    |v5.0.1        |
+|make                               |package   |4.3           |
+|openshift                          |binary    |4.14.20       |
+|python3-pip                        |package   |21.2.3        |
+|python3-pytest                     |package   |6.2.2         |
+|python                             |package   |3.9.18        |
+|redhat_cop.controller_configuration|collection|2.3.1         |
+|sshpass                            |package   |1.09          |
+|tar                                |package   |1.34          |
+|tekton                             |binary    |0.35.2        |
+|vi                                 |package   |8.2.2637      |
+|vp-qe-test-common                  |pip       |0.1.0         |
 
 ## Usage
 **Pull the image**


### PR DESCRIPTION
infra. does not deprecate or redirect, and there is code still that uses the FQCN for redhat_cop in patterns, and likely in the wild. This will prevent nasty surprises with the collection not being found.