### PR TITLE
Add tea (for gitea support) and ansible-runner (for use as ee)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -30,6 +30,7 @@ ARG HELM_VERSION="3.13.3"
 ARG ARGOCD_VERSION="2.9.7"
 ARG TKN_CLI_VERSION="0.35.2"
 ARG YQ_VERSION="4.40.7"
+ARG TEA_VERSION="0.9.2"
 
 # amd64 - arm64
 ARG TARGETARCH
@@ -64,11 +65,12 @@ curl -sLfO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT
 tar xvf openshift-client-linux-${OPTTARGETARCH}${OPENSHIFT_CLIENT_VERSION}.tar.gz -C /usr/local/bin && \
 rm -rf openshift-client-linux-${OPTTARGETARCH}${OPENSHIFT_CLIENT_VERSION}.tar.gz  && rm -f /usr/local/bin/kubectl && ln -sf /usr/local/bin/oc /usr/local/bin/kubectl && \
 curl -sSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH} && chmod 755 /usr/local/bin/yq && \
+curl -sSL -o /usr/local/bin/tea https://gitea.com/gitea/tea/releases/download/v${TEA_VERSION}/tea-${TEA_VERSION}-linux-${TARGETARCH} && chmod 755 /usr/local/bin/tea && \
 rm -rf /root/anaconda* /root/original-ks.cfg /usr/local/README
 
 # The hypershift cli is downloaded directly from the cluster.
 # This could change when HCP goes GA - the alternative would
-# be to compile our own, so this seemed the logical choice. 
+# be to compile our own, so this seemed the logical choice.
 
 # humanize is only needed for the trimming of the container
 # See https://github.com/Azure/azure-sdk-for-python/issues/11149
@@ -81,7 +83,7 @@ rm -rf /root/anaconda* /root/original-ks.cfg /usr/local/README
 # otherwise whatever user openshift runs the container with won't find the collection
 
 RUN pip3 install --no-cache-dir "ansible-core>=2.9" kubernetes openshift "boto3>=1.21" "botocore>=1.24" "awscli>=1.22" "azure-cli>=2.34" gcloud humanize jmespath awxkit pytz --upgrade && \
-pip3 install --no-cache-dir git+https://github.com/validatedpatterns/vp-qe-test-common.git@development#egg=vp-qe-test-common --upgrade && \
+pip3 install --no-cache-dir ansible-runner git+https://github.com/validatedpatterns/vp-qe-test-common.git@development#egg=vp-qe-test-common --upgrade && \
 ansible-galaxy collection install --collections-path /usr/share/ansible/collections ansible.posix ansible.utils kubernetes.core community.okd redhat_cop.controller_configuration infra.controller_configuration community.general awx.awx amazon.aws && \
 rm -rf /usr/local/lib/python3.9/site-packages/ansible_collections/$COLLECTIONS_TO_REMOVE && \
 curl -L -O https://raw.githubusercontent.com/clumio-code/azure-sdk-trim/main/azure_sdk_trim/azure_sdk_trim.py && \
@@ -90,6 +92,8 @@ if [ -n "$EXTRARPMS" ]; then microdnf remove -y $EXTRARPMS; fi && \
 mkdir -p /pattern/.ansible/tmp /pattern-home/.ansible/tmp && \
 find /pattern/.ansible -type d -exec chmod 770 "{}" \; && \
 find /pattern-home/.ansible -type d -exec chmod 770 "{}" \;
+
+#RUN pip3 install --no-cache-dir ansible-runner
 
 # We will have two important folders:
 # /pattern which will have the current pattern's git repo bindmounted

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TESTCOMMAND := "set -e; echo '* Helm: '; helm version; \
 		echo '* ansible.posix: '; ansible-galaxy collection list | grep ansible.posix ; \
 		echo '* ansible.utils: '; ansible-galaxy collection list | grep ansible.utils ; \
 		echo '* diff: '; diff --version ; \
-		echo '* find: '; find --version"; \
+		echo '* find: '; find --version ; \
 		echo '* tea: '; tea --version" ;
 
 ##@ Help-related tasks
@@ -110,7 +110,7 @@ versions: ## Print all the versions of software in the locally-built container
 		echo -n \"|awxkit pip \"; pip show awxkit| grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
 		echo -n \"|jmespath pip \"; pip show jmespath| grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
 		echo -n \"|ansible-runner pip \"; pip show ansible-runner| grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
-		echo -n \"|vp-qe-test-common pip \"; pip show vp-qe-test-common | grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
+		echo -n \"|vp-qe-test-common pip \"; pip show vp-qe-test-common | grep ^Version: | cut -f2 -d\ | tr -d '\n';  echo \" \"; \
 		echo -n \"|kubernetes.core collection \";  ansible-galaxy collection list kubernetes.core |grep ^kubernetes.core | cut -f2 -d\  |tr -d '\n';  echo \" \"; \
 		echo -n \"|community.okd collection \";  ansible-galaxy collection list community.okd |grep ^community.okd | cut -f2 -d\  |tr -d '\n';  echo \" \"; \
 		echo -n \"|community.general collection \";  ansible-galaxy collection list community.general |grep ^community.general | cut -f2 -d\  |tr -d '\n';  echo \" \"; \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ TESTCOMMAND := "set -e; echo '* Helm: '; helm version; \
 		echo '* ansible.posix: '; ansible-galaxy collection list | grep ansible.posix ; \
 		echo '* ansible.utils: '; ansible-galaxy collection list | grep ansible.utils ; \
 		echo '* diff: '; diff --version ; \
-		echo '* find: '; find --version"
+		echo '* find: '; find --version"; \
+		echo '* tea: '; tea --version" ;
 
 ##@ Help-related tasks
 .PHONY: help
@@ -94,6 +95,7 @@ versions: ## Print all the versions of software in the locally-built container
 		echo -n \"|jq package \"; rpm -q --qf '%{VERSION}' jq;  echo \" \"; \
 		echo -n \"|argocd binary \"; argocd version --client -o json | jq -j '.client.Version';  echo \" \"; \
 		echo -n \"|helm binary \"; helm version --template '{{ .Version }}';  echo \" \"; \
+		echo -n \"|tea binary \"; tea --version | sed -e 's/Version: //' | sed -e 's/golang.*//' | tr -d '\t' | tr -d '\n';  echo \" \"; \
 		echo -n \"|tekton binary \"; tkn version --component client | tr -d '\n';  echo \" \"; \
 		echo -n \"|openshift binary \"; oc version --client -o json | jq -j '.releaseClientVersion';  echo \" \"; \
 		echo -n \"|kustomize binary \"; oc version --client -o json | jq -j '.kustomizeVersion';  echo \" \"; \
@@ -107,6 +109,7 @@ versions: ## Print all the versions of software in the locally-built container
 		echo -n \"|gcloud pip \"; pip show gcloud| grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
 		echo -n \"|awxkit pip \"; pip show awxkit| grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
 		echo -n \"|jmespath pip \"; pip show jmespath| grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
+		echo -n \"|ansible-runner pip \"; pip show ansible-runner| grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
 		echo -n \"|vp-qe-test-common pip \"; pip show vp-qe-test-common | grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \
 		echo -n \"|kubernetes.core collection \";  ansible-galaxy collection list kubernetes.core |grep ^kubernetes.core | cut -f2 -d\  |tr -d '\n';  echo \" \"; \
 		echo -n \"|community.okd collection \";  ansible-galaxy collection list community.okd |grep ^community.okd | cut -f2 -d\  |tr -d '\n';  echo \" \"; \

--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ utility container for simplified execution of imperative commands in each of the
 |:---------------------------------:|:--------:|:------------:|
 |ansible                            |pip       |2.15.12       |
 |ansible.posix                      |collection|1.5.4         |
-|ansible.utils                      |collection|5.0.0         |
+|ansible-runner                     |pip       |2.4.0         |
+|ansible.utils                      |collection|5.1.0         |
 |argocd                             |binary    |v2.9.7+fbb6b20|
-|awscli                             |pip       |1.33.33       |
+|awscli                             |pip       |1.34.8        |
 |awx.awx                            |collection|24.6.1        |
 |awxkit                             |pip       |24.6.1        |
-|azure-cli                          |pip       |2.62.0        |
-|boto3                              |pip       |1.34.151      |
-|botocore                           |pip       |1.34.151      |
-|community.general                  |collection|9.2.0         |
+|azure-cli                          |pip       |2.63.0        |
+|boto3                              |pip       |1.35.8        |
+|botocore                           |pip       |1.35.8        |
+|community.general                  |collection|9.3.0         |
 |community.okd                      |collection|4.0.0         |
 |gcloud                             |pip       |0.18.3        |
 |git-core                           |package   |2.43.5        |
@@ -37,6 +38,7 @@ utility container for simplified execution of imperative commands in each of the
 |redhat_cop.controller_configuration|collection|2.3.1         |
 |sshpass                            |package   |1.09          |
 |tar                                |package   |1.34          |
+|tea                                |binary    |0.9.2         |
 |tekton                             |binary    |0.35.2        |
 |vi                                 |package   |8.2.2637      |
 |vp-qe-test-common                  |pip       |0.1.0         |


### PR DESCRIPTION
* Add the tea binary for interactions with gitea
* Add the ansible-runner pip package to enable container to be used as an AWX or AAP Execution Environment

Update AWS tooling as a side-effect of rebuild