### PR TITLE
Update Ansible to 2.16 including other supporting changes for AGOF

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -96,7 +96,7 @@ rm -rf /root/anaconda* /root/original-ks.cfg /usr/local/README
 
 RUN pip install --no-cache-dir ${ANSIBLE_CORE_SPEC} pytest kubernetes openshift "boto3>=1.21" "botocore>=1.24" "awscli>=1.22" "azure-cli>=2.34" gcloud humanize jmespath awxkit pytz --upgrade && \
 pip install --no-cache-dir ansible-runner git+https://github.com/validatedpatterns/vp-qe-test-common.git@development#egg=vp-qe-test-common --upgrade && \
-ansible-galaxy collection install --collections-path /usr/share/ansible/collections ansible.posix ansible.utils kubernetes.core community.okd redhat_cop.controller_configuration infra.controller_configuration community.general awx.awx amazon.aws && \
+ansible-galaxy collection install --collections-path /usr/share/ansible/collections ansible.posix ansible.utils kubernetes.core community.okd redhat_cop.controller_configuration infra.controller_configuration infra.eda_configuration infra.ah_configuration community.general awx.awx amazon.aws && \
 rm -rf /usr/local/lib/python${PYTHON_VERSION}/site-packages/ansible_collections/$COLLECTIONS_TO_REMOVE && \
 curl -L -O https://raw.githubusercontent.com/clumio-code/azure-sdk-trim/main/azure_sdk_trim/azure_sdk_trim.py && \
 python3 azure_sdk_trim.py && rm azure_sdk_trim.py && pip uninstall -y humanize && \
@@ -114,6 +114,7 @@ find /pattern-home/.ansible -type d -exec chmod 770 "{}" \;
 #USER 1001
 ENV HOME=/pattern-home
 ENV ANSIBLE_REMOTE_TMP=/pattern-home/.ansible/tmp
+ENV ANSIBLE_ASYNC_DIR=/tmp/.ansible/.async
 ENV ANSIBLE_LOCAL_TMP=/pattern-home/.ansible/tmp
 ENV ANSIBLE_LOCALHOST_WARNING=False
 

--- a/Containerfile
+++ b/Containerfile
@@ -52,7 +52,7 @@ ARG EXTRARPMS
 USER root
 
 # 'pip' is expected to be the pip resolved by 'python3 pip' AKA the one we install with PYTHON_VERSION
-RUN microdnf --disableplugin=subscription-manager install -y ${PYTHON_PKGS}
+RUN microdnf --disableplugin=subscription-manager install -y ${PYTHON_PKGS} && microdnf --disableplugin=subscription-manager clean all
 RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 0
 
 RUN microdnf --disableplugin=subscription-manager install -y make git-core tar vi jq which findutils diffutils sshpass $EXTRARPMS && \

--- a/Makefile
+++ b/Makefile
@@ -86,12 +86,11 @@ versions: ## Print all the versions of software in the locally-built container
 		"set -e; \
 		echo -n \"|sshpass package \"; rpm -q --queryformat '%{VERSION}' sshpass; echo \" \"; \
 		echo -n \"|python3-pip package \"; rpm -q --queryformat '%{VERSION}' python3-pip; echo \" \"; \
-		echo -n \"|python3-pytest package \"; rpm -q --queryformat '%{VERSION}' python3-pytest; echo \" \"; \
 		echo -n \"|git-core package \"; rpm -q --qf '%{VERSION}' git-core; echo \" \"; \
 		echo -n \"|vi package \"; rpm -q --qf '%{VERSION}' vim-minimal; echo \" \";  \
 		echo -n \"|tar package \"; rpm -q --qf '%{VERSION}' tar;  echo \" \"; \
 		echo -n \"|make package \"; rpm -q --qf '%{VERSION}' make;  echo \" \"; \
-		echo -n \"|python package \"; rpm -q --qf '%{VERSION}' python3;  echo \" \"; \
+		echo -n \"|python package \";  /usr/bin/python3 --version | sed -e s'/Python //' | tr -d '\n';  echo \" \"; \
 		echo -n \"|jq package \"; rpm -q --qf '%{VERSION}' jq;  echo \" \"; \
 		echo -n \"|argocd binary \"; argocd version --client -o json | jq -j '.client.Version';  echo \" \"; \
 		echo -n \"|helm binary \"; helm version --template '{{ .Version }}';  echo \" \"; \
@@ -100,6 +99,7 @@ versions: ## Print all the versions of software in the locally-built container
 		echo -n \"|openshift binary \"; oc version --client -o json | jq -j '.releaseClientVersion';  echo \" \"; \
 		echo -n \"|kustomize binary \"; oc version --client -o json | jq -j '.kustomizeVersion';  echo \" \"; \
 		echo -n \"|hcp binary \"; hcp --version version | cut -d: -f3 | tr -d '\n';  echo \" \"; \
+		echo -n \"|pytest pip \"; pip show pytest | grep ^Version | cut -f2 -d\  |tr -d '\n'; echo \" \"; \
 		echo -n \"|ansible pip \"; ansible --version -o json | grep core | cut -f3 -d\ | tr -d '\n]';  echo \" \"; \
 		echo -n \"|kubernetes pip \"; pip show kubernetes |grep ^Version: | cut -f2 -d\ | tr -d '\n';  echo \" \"; \
 		echo -n \"|boto3 pip \"; pip show boto3 | grep ^Version: | cut -f2 -d\ |tr -d '\n';  echo \" \"; \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TAG ?= latest
 CONTAINER ?= $(NAME):$(TAG)
 
 REGISTRY ?= localhost
-UPLOADREGISTRY ?= quay.io/rhn_support_mbaldess
+UPLOADREGISTRY ?= quay.io/hybridcloudpatterns
 TESTCOMMAND := "set -e; echo '* Helm: '; helm version; \
 		echo '* ArgoCD: '; argocd version --client ; \
 		echo '* Tekton: '; tkn version ; \

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ TESTCOMMAND := "set -e; echo '* Helm: '; helm version; \
 		echo '* kubernetes.core: '; ansible-galaxy collection list | grep kubernetes.core ; \
 		echo '* redhat_cop.controller_configuration: '; ansible-galaxy collection list | grep redhat_cop.controller_configuration ; \
 		echo '* infra.controller_configuration: '; ansible-galaxy collection list | grep infra.controller_configuration ; \
+		echo '* infra.eda_configuration: '; ansible-galaxy collection list | grep infra.eda_configuration ; \
+		echo '* infra.ah_configuration: '; ansible-galaxy collection list | grep infra.ah_configuration ; \
 		echo '* awx.awx: '; ansible-galaxy collection list | grep awx.awx ; \
 		echo '* community.general: '; ansible-galaxy collection list | grep community.general ; \
 		echo '* ansible.posix: '; ansible-galaxy collection list | grep ansible.posix ; \
@@ -119,6 +121,8 @@ versions: ## Print all the versions of software in the locally-built container
 		echo -n \"|ansible.utils collection \";  ansible-galaxy collection list ansible.utils |grep ^ansible.utils | cut -f2 -d\  |tr -d '\n';  echo \" \"; \
 		echo -n \"|redhat_cop.controller_configuration collection \";  ansible-galaxy collection list redhat_cop.controller_configuration |grep ^redhat_cop.controller_configuration | cut -f2 -d\ | tr -d '\n'; echo \" \";  \
 		echo -n \"|infra.controller_configuration collection \";  ansible-galaxy collection list infra.controller_configuration |grep ^infra.controller_configuration | cut -f2 -d\ | tr -d '\n'; echo \" \";  \
+		echo -n \"|infra.eda_configuration collection \";  ansible-galaxy collection list infra.eda_configuration |grep ^infra.eda_configuration | cut -f2 -d\ | tr -d '\n'; echo \" \";  \
+		echo -n \"|infra.ah_configuration collection \";  ansible-galaxy collection list infra.ah_configuration |grep ^infra.ah_configuration | cut -f2 -d\ | tr -d '\n'; echo \" \";  \
     " | sort | column --table -o '|'
 
 .PHONY: run

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ utility container for simplified execution of imperative commands in each of the
 
 |               name                |  type    |   version    |
 |:---------------------------------:|:--------:|:------------:|
-|ansible                            |pip       |2.15.12       |
+|ansible                            |pip       |2.16.10       |
 |ansible.posix                      |collection|1.5.4         |
 |ansible-runner                     |pip       |2.4.0         |
-|ansible.utils                      |collection|5.1.0         |
+|ansible.utils                      |collection|5.1.1         |
 |argocd                             |binary    |v2.9.7+fbb6b20|
-|awscli                             |pip       |1.34.8        |
+|awscli                             |pip       |1.34.12       |
 |awx.awx                            |collection|24.6.1        |
 |awxkit                             |pip       |24.6.1        |
-|azure-cli                          |pip       |2.63.0        |
-|boto3                              |pip       |1.35.8        |
-|botocore                           |pip       |1.35.8        |
+|azure-cli                          |pip       |2.64.0        |
+|boto3                              |pip       |1.35.12       |
+|botocore                           |pip       |1.35.12       |
 |community.general                  |collection|9.3.0         |
 |community.okd                      |collection|4.0.0         |
 |gcloud                             |pip       |0.18.3        |
@@ -32,9 +32,9 @@ utility container for simplified execution of imperative commands in each of the
 |kustomize                          |binary    |v5.0.1        |
 |make                               |package   |4.3           |
 |openshift                          |binary    |4.14.20       |
+|pytest                             |pip       |8.3.2         |
 |python3-pip                        |package   |21.2.3        |
-|python3-pytest                     |package   |6.2.2         |
-|python                             |package   |3.9.18        |
+|python                             |package   |3.11.7        |
 |redhat_cop.controller_configuration|collection|2.3.1         |
 |sshpass                            |package   |1.09          |
 |tar                                |package   |1.34          |

--- a/README.md
+++ b/README.md
@@ -12,19 +12,21 @@ utility container for simplified execution of imperative commands in each of the
 |ansible-runner                     |pip       |2.4.0         |
 |ansible.utils                      |collection|5.1.1         |
 |argocd                             |binary    |v2.9.7+fbb6b20|
-|awscli                             |pip       |1.34.12       |
+|awscli                             |pip       |1.34.13       |
 |awx.awx                            |collection|24.6.1        |
 |awxkit                             |pip       |24.6.1        |
 |azure-cli                          |pip       |2.64.0        |
-|boto3                              |pip       |1.35.12       |
-|botocore                           |pip       |1.35.12       |
+|boto3                              |pip       |1.35.13       |
+|botocore                           |pip       |1.35.13       |
 |community.general                  |collection|9.3.0         |
 |community.okd                      |collection|4.0.0         |
 |gcloud                             |pip       |0.18.3        |
 |git-core                           |package   |2.43.5        |
 |hcp                                |binary    |4.15.0        |
 |helm                               |binary    |v3.13.3       |
+|infra.ah_configuration             |collection|2.0.6         |
 |infra.controller_configuration     |collection|2.9.0         |
+|infra.eda_configuration            |collection|1.1.0         |
 |jmespath                           |pip       |1.0.1         |
 |jq                                 |package   |1.6           |
 |kubernetes.core                    |collection|5.0.0         |


### PR DESCRIPTION
* Updates utility container ansible-core to Ansible 2.16.
* Include infra.ah_configuratiion and infra.eda_configuration to support AGOF
* Switch pytest from RPM package to pip package and update it
* Set ANSIBLE_ASYNC_DIR environment variable. This works around an issue with ansible's async_dir settings when the env var is not set and enables the dispatch roles for infra.controller_configuration and related collections to complete when run from the container.
* Set default upload location to quay.io/hybridcloudpatterns (the default utility container image location)

This includes a number of other updates to parameterize Python version. Setting python3 is done in the container as a pre-requisite to the rest of container installerion.

Update is to 3.11 because of an incompatibility awxkit has with Python 3.12 at present (setuptools related, as of awxkit 24.6.1).